### PR TITLE
Fix axios export name in api.ts

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios'
+import axios, { AxiosResponse } from 'axios'
+import type { AxiosInstance } from 'axios'
 
 // Create axios instance
 const api: AxiosInstance = axios.create({


### PR DESCRIPTION
Fix `AxiosInstance` import to resolve `Uncaught SyntaxError` because it is no longer a named export in Axios 1.x and requires a type-only import.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0c31b37-ee53-40ce-a906-6e8fd6750eb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0c31b37-ee53-40ce-a906-6e8fd6750eb8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

